### PR TITLE
Additional inflection rules.

### DIFF
--- a/lib/motion_model/ext.rb
+++ b/lib/motion_model/ext.rb
@@ -64,31 +64,87 @@ class Inflector
     # Put singular-form to plural form transformations here
     @plurals = [
       [/^person$/, 'people'],
-      [/^identity$/, 'identities'],
+      [/^man$/, 'men'],
       [/^child$/, 'children'],
-      [/^(.*)ee$/i, '\1ees'],     # attendee => attendees
-      [/^(.*)us$/i, '\1i'],       # alumnus  => alumni
-      [/^(.*s)$/i, '\1es'],       # pass     => passes
-      [/^(.*)$/, '\1s']           # normal   => normals
+      [/^sex$/, 'sexes'],
+      [/^move$/, 'moves'],
+      [/^cow$/, 'kine'],
+      [/^zombie$/, 'zombies'],
+      [/(quiz)$/i, '\1zes'],
+      [/^(oxen)$/i, '\1'],
+      [/^(ox)$/i, '\1en'],
+      [/^(m|l)ice$/i, '\1ice'],
+      [/^(m|l)ouse$/i, '\1ice'],
+      [/(matr|vert|ind)(?:ix|ex)$/i, '\1ices'],
+      [/(x|ch|ss|sh)$/i, '\1es'],
+      [/([^aeiouy]|qu)y$/i, '\1ies'],
+      [/(hive)$/i, '\1s'],
+      [/(?:([^f])fe|([lr])f)$/i, '\1\2ves'],
+      [/sis$/i, 'ses'],
+      [/([ti])a$/i, '\1a'],
+      [/([ti])um$/i, '\1a'],
+      [/(buffal|tomat)o$/i, '\1oes'],
+      [/(bu)s$/i, '\1ses'],
+      [/(alias|status)$/i, '\1es'],
+      [/(octop|vir)i$/i, '\1i'],
+      [/(octop|vir|alumn)us$/i, '\1i'],
+      [/^(ax|test)is$/i, '\1es'],
+      [/s$/i, 's'],
+      [/$/, 's']
     ]
 
     # Put plural-form to singular form transformations here
     @singulars = [
       [/^people$/, 'person'],
-      [/^identities$/, 'identity'],
+      [/^men$/, 'man'],
       [/^children$/, 'child'],
-      [/^(.*)ees$/i, '\1ee'],     # attendees  => attendee
-      [/^(.*)es$/i, '\1'],        # passes     => pass
-      [/^(.*)i$/i, '\1us'],       # alumni     => alumnus
-      [/^(.*)s$/i, '\1']          # normals    => normal
+      [/^sexes$/, 'sex'],
+      [/^moves$/, 'move'],
+      [/^kine$/, 'cow'],
+      [/^zombies$/, 'zombie'],
+      [/(database)s$/i, '\1'],
+      [/(quiz)zes$/i, '\1'],
+      [/(matr)ices$/i, '\1ix'],
+      [/(vert|ind)ices$/i, '\1ex'],
+      [/^(ox)en/i, '\1'],
+      [/(alias|status)(es)?$/i, '\1'],
+      [/(octop|vir|alumn)(us|i)$/i, '\1us'],
+      [/^(a)x[ie]s$/i, '\1xis'],
+      [/(cris|test)(is|es)$/i, '\1is'],
+      [/(shoe)s$/i, '\1'],
+      [/(o)es$/i, '\1'],
+      [/(bus)(es)?$/i, '\1'],
+      [/^(m|l)ice$/i, '\1ouse'],
+      [/(x|ch|ss|sh)es$/i, '\1'],
+      [/(m)ovies$/i, '\1ovie'],
+      [/(s)eries$/i, '\1eries'],
+      [/([^aeiouy]|qu)ies$/i, '\1y'],
+      [/([lr])ves$/i, '\1f'],
+      [/(tive)s$/i, '\1'],
+      [/(hive)s$/i, '\1'],
+      [/([^f])ves$/i, '\1fe'],
+      [/(^analy)(sis|ses)$/i, '\1sis'],
+      [/((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)(sis|ses)$/i, '\1sis'],
+      [/([ti])a$/i, '\1um'],
+      [/(n)ews$/i, '\1ews'],
+      [/(ss)$/i, '\1'],
+      [/s$/i, '']
     ]
 
     @irregulars = [
     ]
 
     @uncountables = [
+      'equipment',
+      'information',
+      'rice',
+      'money',
+      'species',
+      'series',
       'fish',
-      'sheep'
+      'sheep',
+      'jeans',
+      'police'
     ]
   end
 

--- a/spec/ext_spec.rb
+++ b/spec/ext_spec.rb
@@ -3,38 +3,46 @@ describe 'Extensions' do
     it 'pluralizes a normal word: dog' do
       Inflector.inflections.pluralize('dog').should == 'dogs'
     end
-  
+
     it 'pluralizes words that end in "s": pass' do
       Inflector.inflections.pluralize('pass').should == 'passes'
     end
-    
+
     it "pluralizes words that end in 'us'" do
       Inflector.inflections.pluralize('alumnus').should == 'alumni'
     end
-    
+
     it "pluralizes words that end in 'ee'" do
       Inflector.inflections.pluralize('attendee').should == 'attendees'
     end
+
+    it "pluralizes words that end in 'e'" do
+      Inflector.inflections.pluralize('article').should == 'articles'
+    end
   end
-  
+
   describe 'Singularization' do
     it 'singularizes a normal word: "dogs"' do
       Inflector.inflections.singularize('dogs').should == 'dog'
     end
-    
+
     it "singualarizes a word that ends in 's': passes" do
       Inflector.inflections.singularize('passes').should == 'pass'
     end
-    
+
     it "singualarizes a word that ends in 'ee': assignees" do
       Inflector.inflections.singularize('assignees').should == 'assignee'
     end
-    
+
     it "singualarizes words that end in 'us'" do
       Inflector.inflections.singularize('alumni').should == 'alumnus'
     end
+
+    it "singualarizes words that end in 'es'" do
+      Inflector.inflections.singularize('articles').should == 'article'
+    end
   end
-  
+
   describe 'Irregular Patterns' do
     it "handles person to people singularizing" do
       Inflector.inflections.singularize('people').should == 'person'
@@ -44,7 +52,7 @@ describe 'Extensions' do
       Inflector.inflections.pluralize('person').should == 'people'
     end
   end
-  
+
   describe 'Adding Rules to Inflector' do
     it 'accepts new rules' do
       Inflector.inflections.irregular /^foot$/, 'feet'


### PR DESCRIPTION
I ran into a problem when declaring a `has_many` relation called `articles`. When singularized it turned into `articl`.

I have added a bunch of inflection rules, shamelessly lifted from https://github.com/hookercookerman/motion_support.
Also added tests for the `article` case.

It's yours if you want it!
