### PR TITLE
Behaving more like ActiveRecord.

### DIFF
--- a/lib/motion_model/model/model.rb
+++ b/lib/motion_model/model/model.rb
@@ -400,7 +400,7 @@ module MotionModel
     # Save current object. Speaking from the context of relational
     # databases, this inserts a row if it's a new one, or updates
     # in place if not.
-    def save
+    def save(*)
       call_hooks 'save' do
         @dirty = false
 

--- a/lib/motion_model/paranoid.rb
+++ b/lib/motion_model/paranoid.rb
@@ -1,0 +1,20 @@
+module MotionModel
+
+  class MotionModel::RecordInvalid < RuntimeError; end
+  
+  module Paranoid
+
+
+    # It doesn't save when validations fails
+    def save(options={ :validate => true})
+      (valid? || !options[:validate]) ? super : false
+    end
+
+    # it fails loudly
+    def save!
+      raise MotionModel::RecordInvalid unless valid?
+      save
+    end
+
+  end
+end

--- a/spec/paranoid_spec.rb
+++ b/spec/paranoid_spec.rb
@@ -1,0 +1,35 @@
+class VTask
+  include MotionModel::Model
+  include MotionModel::Validatable
+  include MotionModel::Paranoid
+
+  columns :name => :string
+  validate :name, :presence => true
+end
+
+describe "Paranoid" do
+
+  it "fails loudly" do
+    task = VTask.new
+    lambda { task.save!}.should.raise(MotionModel::RecordInvalid)
+  end
+
+  it "can skip the validations" do 
+    task = VTask.new
+    lambda { task.save({:validate => false})}.should.change { VTask.count }
+  end
+
+  it "should not save when validation fails" do
+    task = VTask.new
+    lambda { task.save }.should.not.change{ VTask.count }
+    task.save.should == false
+  end
+
+  it "saves it when everything is ok" do
+    task = VTask.new
+    task.name = "Save it"
+    lambda { task.save }.should.change { VTask.count }
+  end
+
+
+end


### PR DESCRIPTION
- We fail loudly when save! is used.
- We don't save when validations fail
- We can skip validations passing in {:validate => true}

hi!  This is in reference to: https://github.com/sxross/MotionModel/pull/17 

I needed to add that def save(*) in order to be able to pass in the Hash to skip the validations like ActiveRecord. I hope it is ok.  :+1: 
