### PR TITLE
Behaving more like ActiveRecord.

### DIFF
--- a/lib/motion_model/model/model.rb
+++ b/lib/motion_model/model/model.rb
@@ -400,7 +400,7 @@ module MotionModel
     # Save current object. Speaking from the context of relational
     # databases, this inserts a row if it's a new one, or updates
     # in place if not.
-    def save
+    def save(*)
       call_hooks 'save' do
         @dirty = false
 

--- a/lib/motion_model/validatable.rb
+++ b/lib/motion_model/validatable.rb
@@ -1,6 +1,8 @@
 module MotionModel
   module Validatable
     class ValidationSpecificationError < RuntimeError;  end
+    class RecordInvalid < RuntimeError; end
+
 
     def self.included(base)
       base.extend(ClassMethods)
@@ -13,6 +15,8 @@ module MotionModel
           ex = ValidationSpecificationError.new('field not present in validation call')
           raise ex
         end
+
+
     
         if validation_type == {}
           ex = ValidationSpecificationError.new('validation type not present or not a hash')
@@ -28,6 +32,17 @@ module MotionModel
       end
     end
   
+     # It doesn't save when validations fails
+    def save(options={ :validate => true})
+      (valid? || !options[:validate]) ? super : false
+    end
+
+    # it fails loudly
+    def save!
+      raise RecordInvalid.new('failed validation') unless valid?
+      save
+    end
+
     # This has two functions:
     # 
     # * First, it triggers validations.

--- a/spec/validation_spec.rb
+++ b/spec/validation_spec.rb
@@ -102,3 +102,37 @@ describe "validations" do
 
   end
 end
+
+class VTask
+  include MotionModel::Model
+  include MotionModel::Validatable
+
+  columns :name => :string
+  validate :name, :presence => true
+end
+
+describe "saving with validations" do
+
+  it "fails loudly" do
+    task = VTask.new
+    lambda { task.save!}.should.raise
+  end
+
+  it "can skip the validations" do
+    task = VTask.new
+    lambda { task.save({:validate => false})}.should.change { VTask.count }
+  end
+
+  it "should not save when validation fails" do
+    task = VTask.new
+    lambda { task.save }.should.not.change{ VTask.count }
+    task.save.should == false
+  end
+
+  it "saves it when everything is ok" do
+    task = VTask.new
+    task.name = "Save it"
+    lambda { task.save }.should.change { VTask.count }
+  end
+
+end


### PR DESCRIPTION
- We fail loudly when save! is used.
- We don't save when validations fail
- We can skip validations passing in {:validate => true}

Hey @sxross

I added the code to MotionModel::Validatable instead of MotionModel::Model because it doesn't make sense if we don't have validations. 
