### PR TITLE
Checks for presence of :id column before adding it again.

### DIFF
--- a/lib/motion_model/model/model.rb
+++ b/lib/motion_model/model/model.rb
@@ -95,7 +95,7 @@ module MotionModel
           raise ArgumentError.new("arguments to `columns' must be a symbol, a hash, or a hash of hashes -- was #{fields.first}.")
         end
 
-        unless column?(:id)
+        unless columns.include?(:id)
           add_field(:id, :integer)
         end
       end


### PR DESCRIPTION
Fix for https://github.com/sxross/MotionModel/issues/33
