### PR TITLE
Changing the dependency to bubble-wrap 1.3.0

### DIFF
--- a/motion_model.gemspec
+++ b/motion_model.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = "motion_model"
   gem.require_paths = ["lib"]
-  gem.add_dependency 'bubble-wrap', '1.3.0.osx'
+  gem.add_dependency 'bubble-wrap', '1.3.0'
   gem.add_dependency 'motion-support', '>=0.1.0'
   gem.version       = MotionModel::VERSION
 end


### PR DESCRIPTION
Tests are green and verified working on my OS X 1.8.3 setup.

```
Bundler could not find compatible versions for gem "bubble-wrap":
  In Gemfile:
    motion_model (>= 0) ruby depends on
      bubble-wrap (= 1.3.0.osx) ruby

    bubble-wrap (1.3.0)
```
