### PR TITLE
JSON array parsed using bubble wrap is not converted into proper array by cast_to_array

### DIFF
--- a/motion/model/model_casts.rb
+++ b/motion/model/model_casts.rb
@@ -32,7 +32,8 @@ module MotionModel
     end
 
     def cast_to_array(arg)
-      Array(arg)
+      array=*arg
+      array
     end
 
     def cast_to_hash(arg)

--- a/spec/model_casting_spec.rb
+++ b/spec/model_casting_spec.rb
@@ -116,7 +116,12 @@ describe 'Type casting' do
   it 'returns an Array for an array field' do
     @convertible.an_array.should.is_a(Array)
   end
-
+  it 'returns proper array for parsed json data using bubble wrap' do
+    parsed_json = BW::JSON.parse('{"menu_categories":["Lunch"]}')
+    @convertible.an_array = parsed_json["menu_categories"]
+    @convertible.an_array.count.should == 1
+    @convertible.an_array.include?("Lunch").should == true
+  end
   it 'the array field should be the same as the range form' do
     (@convertible.an_array.first..@convertible.an_array.last).should.equal(1..10)
   end


### PR DESCRIPTION
example: 

``` ruby
parsed_json = BW::JSON.parse('{"menu_categories":["Lunch"]}')
Array(parsed_json)
# returns  ["Lunch", nil, nil]
```

I am not quite sure why this problem exists. But I have managed to add a failing spec and temporary fix for this issue.
