### PR TITLE
bugfix: when using ArrayModelAdapter, calling record.save! would raise a...

### DIFF
--- a/motion/adapters/array_model_adapter.rb
+++ b/motion/adapters/array_model_adapter.rb
@@ -164,6 +164,7 @@ module MotionModel
     end
 
     def do_update(options = {})
+      true
     end
 
     def do_delete

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -168,6 +168,12 @@ describe "Creating a model" do
       Task.where(:name).eq('updated').should == 0
       lambda{task.save}.should.change{Task.where(:name).eq('updated')}
     end
+
+    it 'should not raise MotionModel::RecordNotSaved when save! is called' do
+      task = Task.create(:name => 'updateable')
+      task.name = 'updated'
+      lambda{task.save!}.should.not.raise(MotionModel::RecordNotSaved)
+    end
   end
 
   describe 'deleting' do


### PR DESCRIPTION
when using ArrayModelAdapter, calling record.save! would raise an exception for existing records.

the underlying reason is that the ArrayModelAdapter doesn't do anything with save, so it had no return value. But it still should return true to indicate that the record was saved successfully.
