### PR TITLE
finder string equal comparison doesn't work with case-insensitive camelCase

### DIFF
--- a/motion/adapters/array_finder_query.rb
+++ b/motion/adapters/array_finder_query.rb
@@ -39,7 +39,7 @@ module MotionModel
     end
     
     def translate_case(item, case_sensitive)#nodoc
-      item = item.underscore if case_sensitive === false && item.respond_to?(:underscore)
+      item = item.downcase if case_sensitive === false && item.respond_to?(:downcase)
       item
     end
     

--- a/spec/finder_spec.rb
+++ b/spec/finder_spec.rb
@@ -87,6 +87,11 @@ describe 'finders' do
       results.length.should == 3
     end
 
+    it 'handles case-insensitive queries as default' do
+      task = Task.create :name => 'camelCase'
+      Task.find(:name).eq('camelcase').all.length.should == 1
+    end
+
     it 'handles case-sensitive queries' do
       task = Task.create :name => 'Bob'
       Task.find(:name).eq('bob', :case_sensitive => true).all.length.should == 0


### PR DESCRIPTION
When doing an .eq case-insensitive string comparison, it fails if a string is camelCase.

"camelCase" == "camelcase" fails because "camelCase" is being converted to "camel_case"

Where this gets me is I am using a uuid on some objects and I use the uuid to find the object.  In some cases (external) the uuid gets generated in uppercase.  So if I have a uuid that is "bd0fbc27-857b-4af4-b4e1-fc5987c2c4dc" or "BD0FBC27-857B-4AF4-B4E1-FC5987C2C4DC" in uppercase.  These will never be equal because for the comparison "BD0FBC27-857B-4AF4-B4E1-FC5987C2C4DC" get converted to "bd0_fbc27_857_b_4_af4_b4_e1_fc5987_c2_c4_dc"

Thank you for considering this pull request and for MotionModel.
