### PR TITLE
Bugfix for missing after_save call, when updating a model

### DIFF
--- a/motion/adapters/array_model_adapter.rb
+++ b/motion/adapters/array_model_adapter.rb
@@ -164,6 +164,7 @@ module MotionModel
     end
 
     def do_update(options = {})
+      self
     end
 
     def do_delete

--- a/spec/model_hook_spec.rb
+++ b/spec/model_hook_spec.rb
@@ -58,5 +58,11 @@ describe "lifecycle hooks" do
     it "calls after_save hook on save" do
       lambda{@task.save}.should.change{@task.after_save_called}
     end
+
+    it "calls after_save hook on update" do
+      task = Task.last
+      task.instance_variable_set("@after_save_called", false)
+      lambda{task.save}.should.change{task.after_save_called}
+    end
   end
 end


### PR DESCRIPTION
Hi @sxross,

I've found another small bug. When you try to update a model, the after_save hook will not called. I've added a failing spec and a fix. I've fixed it by returning "self" in do_update.

Greets
Torben
