### PR TITLE
Added write_attribute method for attribute setter methods

### DIFF
--- a/motion/model/model.rb
+++ b/motion/model/model.rb
@@ -485,6 +485,11 @@ module MotionModel
     def read_attribute(name)
       @data[name]
     end
+    
+    def write_attribute(attr_name, value)
+      @data[attr_name] = value
+      @dirty = true
+    end
 
     # Default to_i implementation returns value of id column, much as
     # in Rails.

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -16,6 +16,15 @@ class ATask
   columns :name, :details, :some_day
 end
 
+class BTask
+  include MotionModel::Model
+  include MotionModel::ArrayModelAdapter
+  columns :name, :details
+  def details=(value)
+    write_attribute(:details, "overridden")
+  end
+end
+
 class TypeCast
   include MotionModel::Model
   include MotionModel::ArrayModelAdapter
@@ -253,6 +262,25 @@ describe "Creating a model" do
     it 'uses a custom attribute by method' do
       @task.custom_attribute_by_method.should == 'Feed the Cat - Get food, pour out'
     end
+  end
+  
+  describe 'overloading accessors using write_attribute' do
+    before do
+      BTask.delete_all
+    end
+    
+    it 'updates the attribute on creation' do
+      @task = BTask.create :name => 'foo', :details => 'bar'
+      @task.details.should.equal('overridden')
+      @task.should.not.be.dirty
+    end
+    
+    it 'updates the attribute but does not save a new instance' do
+      @task = BTask.new :name => 'foo', :details => 'bar'
+      @task.details.should.equal('overridden')
+      @task.should.be.dirty
+    end
+    
   end
 
   describe 'protecting timestamps' do


### PR DESCRIPTION
*Allows similar use of 'write_attribute' in ActiveRecord for methods that override an attribute setter
*Same as ActiveRecord, write_attribute does not save the model instance
