### PR TITLE
Updates spec to cover multiple relationship assignments of the same value

### DIFF
--- a/spec/relation_spec.rb
+++ b/spec/relation_spec.rb
@@ -195,6 +195,13 @@ describe 'related objects' do
           @t1.assignees.count.should == 1
           @t1.assignees.first.assignee_name.should == @a1.assignee_name
         end
+        
+        it "directly assigning the existing task to an assignee doesn't change anything" do
+          @a1.task = @t1
+          @a1.save
+          @a1.task = @t1
+          @a1.dirty?.should == false
+        end
       end
     end
   end

--- a/spec/relation_spec.rb
+++ b/spec/relation_spec.rb
@@ -202,6 +202,12 @@ describe 'related objects' do
           @a1.task = @t1
           @a1.dirty?.should == false
         end
+        
+        it "directly assigning the assignee a nil task twice doesn't change anything" do
+          @a1.task.should == nil
+          @a1.task = nil
+          @a1.dirty?.should == false
+        end
       end
     end
   end


### PR DESCRIPTION
As requested in #133 covering a crash for missing `#try` method